### PR TITLE
Added File Execution

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
-gcc -c -m64 -Wall -W -pedantic -std=c99 -nostdlib -nostartfiles -nodefaultlibs -fomit-frame-pointer -mno-red-zone -o alloy.o alloy.c
-gcc -c -m64 -Wall -W -pedantic -nostdlib -nostartfiles -nodefaultlibs -fomit-frame-pointer -mno-red-zone -o libBareMetal.o libBareMetal.c
+
+set -u
+set -o errexit
+
+CFLAGS="-m64 -Wall -W -pedantic -nostdlib -nostartfiles -nodefaultlibs -fomit-frame-pointer -mno-red-zone -I$topdir/include"
+
+gcc $CFLAGS -std=c99 -c alloy.c -o alloy.o
+gcc $CFLAGS -std=gnu99 -c libBareMetal.c -o libBareMetal.o
+
 objcopy --remove-section .comment alloy.o
 objcopy --remove-section .eh_frame alloy.o
 objcopy --remove-section .comment libBareMetal.o
 objcopy --remove-section .eh_frame libBareMetal.o
-ld -T app.ld -o alloy.bin alloy.o libBareMetal.o
+ld -T app.ld -static -o alloy.bin alloy.o libBareMetal.o "$topdir/lib/libbmfs.a"

--- a/libBareMetal.c
+++ b/libBareMetal.c
@@ -39,15 +39,19 @@ unsigned long b_smp_config() {
 }
 
 
-unsigned long b_mem_allocate(unsigned long *mem, unsigned long nbr) {
+unsigned long b_mem_allocate(void **mem, unsigned long nbr) {
+	unsigned long mem_addr;
 	unsigned long tlong;
-	asm volatile ("call *0x00100040" : "=a"(*(mem)), "=c"(tlong) : "c"(nbr));
+	asm volatile ("call *0x00100040" : "=a"(mem_addr), "=c"(tlong) : "c"(nbr));
+	(*mem) = (void *)(mem_addr);
 	return tlong;
 }
 
-unsigned long b_mem_release(unsigned long *mem, unsigned long nbr) {
+unsigned long b_mem_release(void **mem, unsigned long nbr) {
 	unsigned long tlong;
-	asm volatile ("call *0x00100048" : "=c"(tlong) : "a"(*(mem)), "c"(nbr));
+	unsigned long mem_addr;
+	mem_addr = (unsigned long)(*mem);
+	asm volatile ("call *0x00100048" : "=c"(tlong) : "a"(mem_addr), "c"(nbr));
 	return tlong;
 }
 

--- a/libBareMetal.c
+++ b/libBareMetal.c
@@ -52,7 +52,7 @@ unsigned long b_mem_release(unsigned long *mem, unsigned long nbr) {
 }
 
 
-void b_ethernet_tx(void *mem, unsigned long len, unsigned long iid) {
+void b_ethernet_tx(const void *mem, unsigned long len, unsigned long iid) {
 	asm volatile ("call *0x00100050" : : "S"(mem), "c"(len), "d"(iid));
 }
 
@@ -69,7 +69,7 @@ unsigned long b_disk_read(void *mem, unsigned long start, unsigned long num, uns
 	return tlong;
 }
 
-unsigned long b_disk_write(void *mem, unsigned long start, unsigned long num, unsigned long disknum) {
+unsigned long b_disk_write(const void *mem, unsigned long start, unsigned long num, unsigned long disknum) {
 	unsigned long tlong = 0;
 	asm volatile ("call *0x00100068" : "=c"(tlong) : "a"(start), "c"(num), "d"(disknum), "S"(mem));
 	return tlong;

--- a/libBareMetal.h
+++ b/libBareMetal.h
@@ -21,8 +21,8 @@ unsigned long b_smp_set(void *codeptr, void *dataptr, unsigned long cpu);
 unsigned long b_smp_config();
 
 // Memory
-unsigned long b_mem_release(unsigned long *mem, unsigned long nbr);
-unsigned long b_mem_allocate(unsigned long *mem, unsigned long nbr);
+unsigned long b_mem_release(void *mem, unsigned long nbr);
+unsigned long b_mem_allocate(void **mem, unsigned long nbr);
 
 // Network
 void b_ethernet_tx(const void *mem, unsigned long len, unsigned long iid);

--- a/libBareMetal.h
+++ b/libBareMetal.h
@@ -25,12 +25,12 @@ unsigned long b_mem_release(unsigned long *mem, unsigned long nbr);
 unsigned long b_mem_allocate(unsigned long *mem, unsigned long nbr);
 
 // Network
-void b_ethernet_tx(void *mem, unsigned long len, unsigned long iid);
+void b_ethernet_tx(const void *mem, unsigned long len, unsigned long iid);
 unsigned long b_ethernet_rx(void *mem, unsigned long iid);
 
 // Disk
 unsigned long b_disk_read(void *mem, unsigned long start, unsigned long num, unsigned long disknum);
-unsigned long b_disk_write(void *mem, unsigned long start, unsigned long num, unsigned long disknum);
+unsigned long b_disk_write(const void *mem, unsigned long start, unsigned long num, unsigned long disknum);
 
 // Misc
 unsigned long b_system_config(unsigned long function, unsigned long var);


### PR DESCRIPTION
This pull request adds the ability for alloy to execute other programs. The only hiccup is that it doesn't release the memory. In order to release the memory, `b_smp_wait` (or something similar) has to be available to Alloy so that the memory isn't released while the process is still running.

This pull request also makes use of the BMFS library to list the directory entries.

A small change was also made to the C prototypes for `b_mem_allocate` and `b_mem_release`, to avoid casting the pointer to an `unsigned long` at every call.